### PR TITLE
Fix "panic: runtime error: index out of range"

### DIFF
--- a/badge.go
+++ b/badge.go
@@ -3,6 +3,7 @@ package badge
 import (
 	"html/template"
 	"io"
+	"sync"
 
 	"github.com/golang/freetype/truetype"
 	"github.com/narqo/go-badge/fonts"
@@ -30,13 +31,16 @@ func (b bounds) Dx() float64 {
 }
 
 type badgeDrawer struct {
-	fd   *font.Drawer
-	tmpl *template.Template
+	fd    *font.Drawer
+	tmpl  *template.Template
+	mutex *sync.Mutex
 }
 
 func (d *badgeDrawer) Render(subject, status string, color Color, w io.Writer) error {
+	d.mutex.Lock()
 	subjectDx := d.measureString(subject)
 	statusDx := d.measureString(status)
+	d.mutex.Unlock()
 
 	bdg := badge{
 		Subject: subject,
@@ -78,6 +82,7 @@ func init() {
 	drawer = &badgeDrawer{
 		fd:   mustNewFontDrawer(fontsize, dpi),
 		tmpl: template.Must(template.New("flat-template").Parse(flatTemplate)),
+		mutex: &sync.Mutex{},
 	}
 }
 

--- a/badge_test.go
+++ b/badge_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func BenchmarkRender(b *testing.B) {
+func BenchmarkRenderSeq(b *testing.B) {
 	// warm up
 	Render("XXX", "YYY", ColorBlue, ioutil.Discard)
 	b.ResetTimer()
@@ -15,4 +15,15 @@ func BenchmarkRender(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func BenchmarkRenderParallel(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			err := Render("XXX", "YYY", ColorBlue, ioutil.Discard)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }


### PR DESCRIPTION
- Add `mutex` to `badgeDrawer` to lock the font drawer while it measures string length.
- Add `BenchmarkRenderParallel` as a dummy test.

fix #8
